### PR TITLE
Fix KeyError in value analysis by escaping JSON braces in prompt template

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -228,15 +228,15 @@ OUTPUT FORMAT:
 
 Your output is ONLY in JSON. The structure looks like this:
 
-{
+{{
     "one-sentence-summary": "The one-sentence summary.",
     "labels": "The labels that apply from the set of options above.",
     "rating:": "S Tier: (Must Consume Original Content This Week) (or whatever the
-    rating is)",
+rating is)",
     "rating-explanation:": "The explanation given for the rating.",
     "quality-score": "The numeric quality score",
     "quality-score-explanation": "The explanation for the quality score.",
-}
+}}
 
 OUTPUT INSTRUCTIONS
 

--- a/podsidian/config.py
+++ b/podsidian/config.py
@@ -97,12 +97,12 @@ OUTPUT INSTRUCTIONS
 
 • Output a valid JSON file with the following fields for the input provided.
 
-{
+{{
 estimated-content-minutes: "(estimated-content-minutes)",
 value-instances: "(list of valid value instances)",
 vpm: "(the calculated VPS score.)",
 vpm-explanation: "(A one-sentence summary of less than 20 words on how you calculated the VPM for the content.)"
-}
+}}
 
 Transcript:
 {transcript}


### PR DESCRIPTION
Problem
When processing podcast episodes with value analysis enabled (value_prompt_enabled = true), the application fails with a KeyError during the Obsidian export phase. The error message shows: Failed to write to Obsidian: '\n "one-sentence-summary"'

Root Cause
The issue occurs in the _get_value_analysis() method when formatting the value_prompt template. The prompt contains a JSON example with single braces { and }, which Python's str.format() method interprets as format placeholders. Since no arguments are provided for these placeholders (like "one-sentence-summary"), a KeyError is raised.

Solution
Escape the JSON braces in the prompt template by doubling them ({{ and }}), so they are treated as literal braces rather than format specifiers. This allows the JSON example to be included in the prompt without interfering with string formatting.

Files Changed
podsidian/config.py: Updated the default value_prompt to use escaped braces in the JSON example.
config.toml.example: Updated the example configuration with the same fix.
Testing
The fix ensures that podcast processing completes successfully when value analysis is enabled, allowing episodes to be exported to Obsidian without errors.